### PR TITLE
Fix resource name for sandbox

### DIFF
--- a/app/administration/settings.py
+++ b/app/administration/settings.py
@@ -427,7 +427,13 @@ STATICFILES_STORAGE = 'storage.handler.AzureStorage'
 
 
 ETL_STORAGE = getenv("ETL_STORAGE")
-ETL_STORAGE_TABLE_NAME = f"c19dash{ENVIRONMENT[0].lower()}uketlfuncInstances"
+# This could be stored in the app configuration and retrieved from there
+# instead of dynamically generate it here
+ETL_STORAGE_TABLE_NAME = (
+    f"c19dash{ENVIRONMENT[0].lower()}uketlfuncInstances"
+    if ENVIRONMENT.upper() != 'SANDBOX'
+    else f"c19dashsbuketlfuncInstances"
+)
 AZURE_CONNECTION_STRING = STORAGE_CREDENTIALS = getenv("DeploymentBlobStorage")
 AZURE_SSL = True
 AZURE_UPLOAD_MAX_CONN = 10


### PR DESCRIPTION
If API_ENV is set correctly in sandbox environment, then this fix should assign correct resource name to: _c19dashsbuketlfuncInstance_ 
The fix would allow to correctly display the status of the processed files.